### PR TITLE
Added timeout when calling data providers. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,40 +26,59 @@ As November 2021, the production environment is accessible at the following URL:
 ## Configuration
 PaNOSC federated search can be configured by setting environmental variables.
 Following is the list of the available configurations, their meaning and default value:
-- API_VERSION           : API version used in the running instance.
-                          Default: unknown
-- DOCKER_IMAGE_VERSION  : tag of the docker image used for the running instance, if any.
-                          Default: unknown
-- HOSTING_FACILITY      : name of the hosting facility for the running instance.
-                          Default: unknown
-- ENVIRONMENT           : string identifying the environemnt where the instance is running.
-                          Example: develop, test, or production.
-                          Default: unknown
-- PROVIDERS             : comma separated list of facilities PaNOSC local search apis that are used when running queries.
-                          Example: "https://icatplus.esrf.fr/api,https://scicat.ess.eu/panosc-api,https://fairdata.ill.fr/fairdata/api"
-                          Default: unknown
-- DEFAULT_LIMIT         : number of results returned from each facility if no limit is provided in filter.
-                          Example: if set to 10. When no limit is provided in filter, the federated search will return 10 results from each facility.
-                          Default: 100
+-   API_VERSION  
+    API version used in the running instance.   
+    Default: unknown  
 
+-   DOCKER_IMAGE_VERSION  
+    tag of the docker image used for the running instance, if any.  
+    Default: unknown  
+ 
+-   HOSTING_FACILITY  
+    name of the hosting facility for the running instance.  
+    Default: unknown  
+
+-   ENVIRONMENT   
+    string identifying the environemnt where the instance is running.  
+    Example: develop, test, or production.  
+    Default: unknown  
+
+-   PROVIDERS  
+    comma separated list of facilities PaNOSC local search apis that are used when running queries.  
+    Example: "https://icatplus.esrf.fr/api,https://scicat.ess.eu/panosc-api,https://fairdata.ill.fr/fairdata/api"  
+    Default: unknown  
+
+-   DEFAULT_LIMIT  
+    number of results returned from each facility if no limit is provided in filter.  
+    Example: if set to 10. When no limit is provided in filter, the federated search will return 10 results from each facility.  
+    Default: 100  
+
+-   PROVIDER_TIMEOUT  
+    timeout in ms when waiting for results from each individual data provider.  
+    Default: 5000  
+  
+   
 All of this values can be verified by connecting to the base URL of the PaNOSC federated search instance that we would like to check.
 For example, the ESS PaNOSC federated search instance returns the following values:
 
+```
 > curl https://federated.scicat.ess.eu/
 {
-   "uptime_seconds" : 426443.573,
-   "uptime" : "118:27:23",
-   "api_version" : "v2.2",
+   "uptime_seconds"       : 426443.573,
+   "uptime"               : "118:27:23",
+   "api_version"          : "v2.2",
    "docker_image_version" : "v2.2",
-   "hosting_facility" : "ESS",
-   "environment" : "production",
+   "hosting_facility"     : "ESS",
+   "environment"          : "production",
+   "default_limit"        : 100,
+   "provider_timeout_ms"  : 1000,
    "data_providers" : [
       "https://icatplus.esrf.fr/api",
       "https://scicat.ess.eu/panosc-api",
       "https://fairdata.ill.fr/fairdata/api"
-   ],
-   "default_limit": : 100
+   ]
 }
+```
 
 ## Example queries
 

--- a/search-api/server/boot/root.js
+++ b/search-api/server/boot/root.js
@@ -15,6 +15,7 @@ module.exports = function (server) {
     const hosting_facility = process.env.HOSTING_FACILITY || "unknown";
     const environment = process.env.ENVIRONMENT || "unknown";
     const data_providers = process.env.PROVIDERS.split(',') || ["unknown"];
+    const provider_timeout_ms = parseInt(process.env.PROVIDER_TIMEOUT || "1000");
     const default_limit = parseInt(process.env.DEFAULT_LIMIT || "100");
 
 
@@ -39,6 +40,7 @@ module.exports = function (server) {
       'hosting_facility': hosting_facility,
       'environment': environment,
       'data_providers': data_providers,
+      'provider_timeout_ms' : provider_timeout_ms,
       'default_limit' : default_limit
     };
 

--- a/search-api/server/datasources.local.js
+++ b/search-api/server/datasources.local.js
@@ -6,6 +6,7 @@ module.exports = {
   "DistributedService": {
     "name": "DistributedService",
     "connector": "distributedConnector",
-    "urls": (process.env.PROVIDERS || "").split(',')
+    "urls": (process.env.PROVIDERS || "").split(','),
+    "timeout" : (process.env.PROVIDER_TIMEOUT || 1000)
   }
 }


### PR DESCRIPTION
This PR address the following items:
- adds a timeout when performing calls to data providers. If the data providers does not response within the timeout, the API forces the results to be an empty set. Timeout can be set through the  environmental variable PROVIDER_TIMEOUT. The timeout is included in the status report.
- limit will be enforced if not specified in the query received
- updated README file