### PR TITLE
Invalid scores are not changed, only reported in log

### DIFF
--- a/search-api/common/mixins/score.js
+++ b/search-api/common/mixins/score.js
@@ -7,7 +7,9 @@ module.exports = (Model, options) => {
       //console.log("Model:afterRemote:test : " + !('score' in instance));
       if (!('score' in instance) || typeof (instance.score) != 'number' || instance.score < 0 || instance.score >= 1) {
         //console.log("Model:afterRemote setting score to 0");
-        instance.score = 0;
+        //instance.score = 0;
+        console.log("Model.afterRemote: invalid score");
+        console.log("Model.afterRemote:Result: " + JSON.stringify(instance));
       }
     });
     next();


### PR DESCRIPTION
With this PR, invalid scores will be reported in log and not changed anymore.
This change will allow us to check better raw results coming from the facilities and provide better statistics on the quality of the results